### PR TITLE
pyproject: replace default project description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@
 
 [project]
 name = "austin-python"
-description = "Create a pyproject.toml file for an existing project."
+description = "Python wrapper for Austin, the CPython frame stack sampler."
 authors = [
   {name = "Gabriele N. Tornetta", email="phoenix1987@gmail.com"},
 ]


### PR DESCRIPTION
### Description of the Change

The project description in `pyproject.toml` was left to its default value filled in by poetry. This ends up being user visible on places like PyPI:

![out_003](https://user-images.githubusercontent.com/202798/199040729-3b611a8b-9160-463e-a9c4-52a7670b2a28.png)

I picked the short description from this GitHub repo as a replacement.

### Alternate Designs

n/a

### Regressions

n/a

### Verification Process

n/a
