### PR TITLE
feat(format): add support for MOJO v3

### DIFF
--- a/test/format/test_mojo.py
+++ b/test/format/test_mojo.py
@@ -31,6 +31,7 @@ import pytest
 
 from austin.format.mojo import MojoFile
 from austin.format.mojo import MojoFrame
+from austin.format.mojo import MojoStack
 from austin.format.mojo import MojoString
 from austin.format.mojo import MojoStringReference
 from austin.format.mojo import main
@@ -161,3 +162,8 @@ def test_mojo_column_info():
                 column_end=17,
             ),
         }
+
+
+def test_mojo_stack():
+    assert MojoStack(1, -1, "noiid").to_austin() == "P1;Tnoiid"
+    assert MojoStack(1, 2, "iid").to_austin() == "P1;T2:iid"


### PR DESCRIPTION
We add support for the version 3 of the MOJO binary spec, which adds support for sub-interpreter identification.

### Requirements for Adding, Changing, Fixing or Removing a Feature

Fill out the template below. Any pull request that does not include enough
information to be reviewed in a timely manner may be closed at the maintainers'
discretion.


### Description of the Change

<!--

Please give a brief but exhaustive description of the changes contained in the
PR.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version
was selected -->

### Regressions

<!-- What are the possible side-effects or negative impacts of the code change?
Would any user of austin be forced to adapt their scripts or code if they wanted
to upgrade to the new version? If so, please try to give an estimate of the
effort involved.
-->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?
- How did you verify that the change has not introduced any memory leaks?

-->
