### PR TITLE
tests: remove timeout from async tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
           pip install hatch
 
       - name: Run tests
-        timeout-minutes: 30
+        timeout-minutes: 10
         run: |
           cd $GITHUB_WORKSPACE/main
           export PATH="$GITHUB_WORKSPACE/austin/src:$PATH"
@@ -102,7 +102,7 @@ jobs:
           pip install hatch
 
       - name: Run tests
-        timeout-minutes: 30
+        timeout-minutes: 10
         run: |
           cd $GITHUB_WORKSPACE/main
           export PATH="$GITHUB_WORKSPACE/austin/src:$PATH"
@@ -142,7 +142,7 @@ jobs:
           pip install hatch
 
       - name: Run tests
-        timeout-minutes: 30
+        timeout-minutes: 10
         run: |
           cd $env:GITHUB_WORKSPACE/main
           $env:PATH="$env:GITHUB_WORKSPACE\austin\src;$env:PATH"

--- a/test/test_aio.py
+++ b/test/test_aio.py
@@ -77,8 +77,6 @@ async def test_async_time():
 
     await austin.start(
         [
-            "-t",
-            "10",
             "-Ci",
             "100",
             "python",
@@ -103,8 +101,6 @@ async def test_async_memory():
     austin._sample_callback = sample_callback
     await austin.start(
         [
-            "-t",
-            "10",
             "-mCi",
             "100",
             "python",
@@ -131,7 +127,7 @@ async def test_async_terminate():
     austin._terminate_callback = terminate_callback
 
     try:
-        await asyncio.wait_for(austin.start(["-t", "10", "-Ci", "10ms", "python"]), 30)
+        await asyncio.wait_for(austin.start(["-Ci", "10ms", "python"]), 30)
     except AustinError:
         austin.assert_callbacks_called()
 


### PR DESCRIPTION
With the latest changes to Austin there should be no need for the timeout argument, so we remove it.