### PR TITLE
perf: avoid repeatedly re-parsing frames

### DIFF
--- a/austin/stats.py
+++ b/austin/stats.py
@@ -260,13 +260,13 @@ class Sample:
 
         try:
             ms = Metric.parse(metrics, metric_type)
-            frames = [Frame.parse(frame) for frame in frames.split(";")] if frames else []
+            frames_parsed = [Frame.parse(frame) for frame in frames.split(";")] if frames else []
             return [
                 Sample(
                     pid=int(pid),
                     thread=thread,
                     metric=metric,
-                    frames=frames,
+                    frames=frames_parsed,
                 )
                 for metric in ms
             ]

--- a/austin/stats.py
+++ b/austin/stats.py
@@ -149,10 +149,14 @@ class Metric:
             ms = [int(_) for _ in metrics.split(",")]
             if len(ms) == 3:
                 return [
-                    Metric(MetricType.TIME, ms[0] if ms[1] == 0 else 0),  # cpu time
-                    Metric(MetricType.TIME, ms[0]),  # wall time
-                    Metric(MetricType.MEMORY, ms[2] if ms[2] >= 0 else 0),  # memory allocation
-                    Metric(MetricType.MEMORY, -ms[2] if ms[2] < 0 else 0),  # memory deallocation
+                    # CPU time
+                    Metric(MetricType.TIME, ms[0] if ms[1] == 0 else 0),
+                    # Wall time
+                    Metric(MetricType.TIME, ms[0]),
+                    # Memory allocation
+                    Metric(MetricType.MEMORY, ms[2] if ms[2] >= 0 else 0),
+                    # Memory deallocation
+                    Metric(MetricType.MEMORY, -ms[2] if ms[2] < 0 else 0),
                 ]
             elif len(ms) != 1:
                 raise ValueError()

--- a/austin/stats.py
+++ b/austin/stats.py
@@ -149,10 +149,10 @@ class Metric:
             ms = [int(_) for _ in metrics.split(",")]
             if len(ms) == 3:
                 return [
-                    Metric(MetricType.TIME, ms[0] if ms[1] == 0 else 0),
-                    Metric(MetricType.TIME, ms[0]),
-                    Metric(MetricType.MEMORY, ms[2] if ms[2] >= 0 else 0),
-                    Metric(MetricType.MEMORY, -ms[2] if ms[2] < 0 else 0),
+                    Metric(MetricType.TIME, ms[0] if ms[1] == 0 else 0),  # cpu time
+                    Metric(MetricType.TIME, ms[0]),  # wall time
+                    Metric(MetricType.MEMORY, ms[2] if ms[2] >= 0 else 0),  # memory allocation
+                    Metric(MetricType.MEMORY, -ms[2] if ms[2] < 0 else 0),  # memory deallocation
                 ]
             elif len(ms) != 1:
                 raise ValueError()
@@ -260,14 +260,13 @@ class Sample:
 
         try:
             ms = Metric.parse(metrics, metric_type)
+            frames = [Frame.parse(frame) for frame in frames.split(";")] if frames else []
             return [
                 Sample(
                     pid=int(pid),
                     thread=thread,
                     metric=metric,
-                    frames=[Frame.parse(frame) for frame in frames.split(";")]
-                    if frames
-                    else [],
+                    frames=frames,
                 )
                 for metric in ms
             ]

--- a/austin/stats.py
+++ b/austin/stats.py
@@ -264,7 +264,9 @@ class Sample:
 
         try:
             ms = Metric.parse(metrics, metric_type)
-            frames_parsed = [Frame.parse(frame) for frame in frames.split(";")] if frames else []
+            frames_parsed = (
+                [Frame.parse(frame) for frame in frames.split(";")] if frames else []
+            )
             return [
                 Sample(
                     pid=int(pid),


### PR DESCRIPTION
Hi there! Thanks for producing such an excellent tool. This was a small optimisation I spotted while looking at `stats.py` to learn more about the Austin trace/profile file format.

This should reduce the effort on parsing frames by a factor of 4 when operating on a `--full` trace, because in that case `ms` will be a list of 4 metrics but we only need to parse the frames once because they are the same in all cases.

Also add a couple of comments in `Metric.parse` which weren't obvious to me on first reading, I hope that's ok.