### PR TITLE
fix: correct units for memory metrics

### DIFF
--- a/austin/stats.py
+++ b/austin/stats.py
@@ -45,7 +45,7 @@ from austin import AustinError
 ThreadName = str
 ProcessId = int
 MicroSeconds = int
-KiloBytes = int
+Bytes = int
 
 
 # ---- Exceptions ----
@@ -106,7 +106,7 @@ class Metric:
     """Austin metrics."""
 
     type: MetricType
-    value: Union[MicroSeconds, KiloBytes] = 0
+    value: Union[MicroSeconds, Bytes] = 0
 
     def __add__(self, other: "Metric") -> "Metric":
         """Add metrics together (algebraically)."""


### PR DESCRIPTION
Fixes #28 (unless I've misunderstood in which case this may be nonsense sorry... but I hope not!)

As described in the issue, I believe the value here is always bytes, it's just the type name which is confusing.