### PR TITLE
Show progress in austin2speedscope

### DIFF
--- a/austin/format/speedscope.py
+++ b/austin/format/speedscope.py
@@ -22,6 +22,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
+import time
 from dataclasses import asdict
 from dataclasses import dataclass
 from dataclasses import field
@@ -211,7 +212,12 @@ def main() -> None:
         with AustinFileReader(args.input) as fin:
             mode = fin.metadata["mode"]
             speedscope = Speedscope(os.path.basename(args.input), mode, args.indent)
+            print(f"Reading Austin samples from: {args.input} ...")
+            n_processed = 0
             for line in fin:
+                n_processed += 1
+                if n_processed % 10000 == 0:
+                    print(".", end="", flush=True)
                 try:
                     speedscope.add_samples(
                         Sample.parse(line, MetricType.from_mode(mode))
@@ -223,9 +229,12 @@ def main() -> None:
         print(f"No such input file: {args.input}")
         exit(1)
 
+    print(f"Writing Speedscope JSON to: {args.output} ...")
     with open(args.output, "w") as fout:
         speedscope.dump(fout)
 
 
 if __name__ == "__main__":
+    start_time = time.monotonic()
     main()
+    print("Conversion completed in %.1f seconds" % (time.monotonic() - start_time))

--- a/austin/format/speedscope.py
+++ b/austin/format/speedscope.py
@@ -208,6 +208,7 @@ def main() -> None:
 
     args = arg_parser.parse_args()
 
+    start_time = time.monotonic()
     try:
         with AustinFileReader(args.input) as fin:
             mode = fin.metadata["mode"]
@@ -222,14 +223,14 @@ def main() -> None:
                 if lines_processed % 1000 == 0:
                     # Show some progress because this can take a long time for huge traces
                     progress = bytes_processed / size_bytes * 100.0
-                    print(f"{progress:.1f}%\r", end="", flush=True)
+                    print(f"\r{progress:.1f}%", end="", flush=True)
                 try:
                     speedscope.add_samples(
                         Sample.parse(line, MetricType.from_mode(mode))
                     )
                 except InvalidSample:
                     continue
-            print("")  # newline after the progress dots so that subsequent output is on its own line
+            print("")  # newline after progress so that subsequent output is on its own line
 
     except FileNotFoundError:
         print(f"No such input file: {args.input}")
@@ -239,8 +240,8 @@ def main() -> None:
     with open(args.output, "w") as fout:
         speedscope.dump(fout)
 
+    print("Conversion complete - total duration: %s" % time.strftime('%Hh %Mm %Ss', time.gmtime(time.monotonic() - start_time)))
+
 
 if __name__ == "__main__":
-    start_time = time.monotonic()
     main()
-    print("Conversion completed in %.1f seconds" % (time.monotonic() - start_time))

--- a/austin/stats.py
+++ b/austin/stats.py
@@ -22,6 +22,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import dataclasses
+import os.path
 import re
 from copy import deepcopy
 from dataclasses import dataclass
@@ -410,6 +411,9 @@ class AustinFileReader:
             if not line.startswith("# ") or line == "\n":
                 break
             self.metadata.add(line)
+
+    def file_size_bytes(self) -> int:
+        return os.path.getsize(self.file)
 
     def __enter__(self) -> "AustinFileReader":
         """Open the Austin file and read the metadata."""


### PR DESCRIPTION
### Description of the Change

Show progress (rather than nothing) during `austin2speedscope` as it can take a long time. As discussed here https://github.com/P403n1x87/austin-python/issues/31

### Alternate Designs

Possible alternative [here](https://github.com/P403n1x87/austin-python/issues/31#issuecomment-2585197804) which may be good longer term, though right now I'm afraid I don't have time to dedicate to it.

### Regressions

Hopefully none - only the CLI output is affected.

### Verification Process

This has been tested on windows & linux with large austin traces and works as I would expect.