### PR TITLE
chore: refresh Python supported versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     name: Tests with Python ${{ matrix.python-version }} on Linux
     steps:
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     name: Tests with Python ${{ matrix.python-version }} on MacOS
     steps:
@@ -113,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     name: Tests with Python ${{ matrix.python-version }} on Windows
     steps:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ sphinx:
   configuration: docs/source/conf.py
 formats: all
 python:
-  version: 3.8
+  version: 3.13
   install:
     - requirements: docs/requirements.txt
     - path: .

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ raw samples by aggregation.
 # Compatibility
 
 The latest `austin-python` package is tested on Linux, macOS and Windows with
-Python 3.8-3.12.
+Python 3.9-3.13.
 
 
 # Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,14 +35,14 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
   "protobuf~=3.12",
   "psutil>=5.7.0",
@@ -76,7 +76,7 @@ dependencies = [
 tests = "pytest --cov=austin --cov-report=term-missing --cov-report=xml {args}"
 
 [[tool.hatch.envs.tests.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.checks]
 python = "3.10"


### PR DESCRIPTION
We remove support for 3.8 and add it for 3.13.