### PR TITLE
fix: austin2* conversion tools

### DIFF
--- a/austin/format/collapsed_stack.py
+++ b/austin/format/collapsed_stack.py
@@ -48,7 +48,7 @@ def parse_frame(frame: str) -> AustinFrame:
         filename, function, line = frame.rsplit(":", maxsplit=2)
     except ValueError:
         raise InvalidFrame(frame) from None
-    return AustinFrame(filename=filename, function=function, line=int(line))
+    return AustinFrame(filename=filename, function=function, line=int(line or 0))
 
 
 def parse_collapsed_stack(sample: str) -> AustinSample:

--- a/austin/format/pprof/__main__.py
+++ b/austin/format/pprof/__main__.py
@@ -22,6 +22,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from argparse import ArgumentParser
+from pathlib import Path
 
 from austin.events import AustinMetadata
 from austin.events import AustinSample
@@ -41,19 +42,21 @@ def main() -> None:
 
     arg_parser.add_argument(
         "input",
-        type=str,
+        type=Path,
         help="The input file containing Austin samples.",
     )
     arg_parser.add_argument(
-        "output", type=str, help="The name of the output pprof file."
+        "output",
+        type=Path,
+        help="The name of the output pprof file.",
     )
 
-    arg_parser.add_argument("-V", "--version", action="version", version="0.2.0")
+    arg_parser.add_argument("-V", "--version", action="version", version="0.2.1")
 
     args = arg_parser.parse_args()
 
     try:
-        with AustinFileReader(args.input) as fin:
+        with args.input.open() as austin, AustinFileReader(austin) as fin:
             pprof = None
             for e in fin:
                 if isinstance(e, AustinMetadata) and e.name == "mode":

--- a/test/data/austin.json
+++ b/test/data/austin.json
@@ -513,5 +513,5 @@
     }
   ],
   "name": "austin.out",
-  "exporter": "Austin2Speedscope Converter 0.3.0"
+  "exporter": "Austin2Speedscope Converter 0.3.1"
 }


### PR DESCRIPTION
We fix a bug in the austin2speedscope and austin2pprof conversion tools that prevented valid Austin files from being converted.

Fixes #16.