### PR TITLE
chore: ruff isort configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,10 +127,10 @@ source = ["austin"]
 [tool.coverage.report]
 show_missing = true
 
-[tool.isort]
-force_single_line = true
-lines_after_imports = 2
-profile = "black"
+[tool.ruff.lint.isort]
+force-single-line = true
+lines-after-imports = 2
+force-sort-within-sections = true
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
We make the isort configuration part of the ruff linter.